### PR TITLE
Don't lint/format CSS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
     "typescript": "~4.6.2"
   },
   "lint-staged": {
-    "src/**/*.{ts,css,html}": "eslint --fix"
+    "src/**/*.{ts,html}": "eslint --fix"
   }
 }


### PR DESCRIPTION
Small PR. ESLint doesn't easily support linting/formatting CSS files. I need this change so that I can push the "Metamask interaction PR".