### PR TITLE
Better UX and integration with Metamask

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser-dynamic": "~13.3.0",
         "@angular/router": "~13.3.0",
         "@mapbox/mapbox-gl-draw": "^1.3.0",
+        "@metamask/detect-provider": "^1.2.0",
         "@types/mapbox__mapbox-gl-draw": "^1.2.5",
         "@vaimee/desmold-sdk": "^1.0.0-alpha.16",
         "ethers": "^5.6.8",
@@ -3689,6 +3690,14 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@metamask/detect-provider": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-1.2.0.tgz",
+      "integrity": "sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@ngtools/webpack": {
@@ -19815,6 +19824,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
+    },
+    "@metamask/detect-provider": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-1.2.0.tgz",
+      "integrity": "sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ=="
     },
     "@ngtools/webpack": {
       "version": "13.3.6",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser-dynamic": "~13.3.0",
     "@angular/router": "~13.3.0",
     "@mapbox/mapbox-gl-draw": "^1.3.0",
+    "@metamask/detect-provider": "^1.2.0",
     "@types/mapbox__mapbox-gl-draw": "^1.2.5",
     "@vaimee/desmold-sdk": "^1.0.0-alpha.16",
     "ethers": "^5.6.8",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,15 +4,35 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { StatisticsPageComponent } from './pages/statistics-page/statistics-page.component';
 import { QueryPageComponent } from './pages/query-page/query-page.component';
+import { NotConnectedPageComponent } from './pages/not-connected-page/not-connected-page.component';
+import { HasMetamaskGuard } from './guards/has-metamask/has-metamask.guard';
+import { IsLoggedInGuard } from './guards/is-logged-in/is-logged-in.guard';
+import { IsVivianiChainGuard } from './guards/is-viviani-chain/is-viviani-chain.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: DefaultComponent,
     children: [
-      { path: '', component: StatisticsPageComponent },
-      { path: 'tdd', component: TddManagerPageComponent },
-      { path: 'query', component: QueryPageComponent },
+      {
+        path: '',
+        component: StatisticsPageComponent,
+        canActivate: [HasMetamaskGuard, IsVivianiChainGuard],
+      },
+      {
+        path: 'tdd',
+        component: TddManagerPageComponent,
+        canActivate: [HasMetamaskGuard, IsVivianiChainGuard, IsLoggedInGuard],
+      },
+      {
+        path: 'query',
+        component: QueryPageComponent,
+        canActivate: [HasMetamaskGuard, IsVivianiChainGuard, IsLoggedInGuard],
+      },
+      {
+        path: 'notconnected',
+        component: NotConnectedPageComponent,
+      },
     ],
   },
 ];

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,37 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Subscription } from 'rxjs';
+import { DesmoldSDKService } from './services/desmold-sdk/desmold-sdk.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit, OnDestroy {
   title = 'desmo-front';
+  private subscriptions: Subscription;
+
+  constructor(
+    private desmold: DesmoldSDKService,
+    private snackBar: MatSnackBar
+  ) {
+    this.subscriptions = new Subscription();
+  }
+
+  async ngOnInit(): Promise<void> {
+    await this.desmold.isReady;
+
+    this.subscriptions.add(
+      this.desmold.accountsChanged.subscribe(() => {
+        this.snackBar.open('The account was successfully changed.', 'Dismiss', {
+          duration: 3000,
+        });
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -41,6 +41,7 @@ import { TddListTableComponent } from './components/tdd-list-table/tdd-list-tabl
 import { QueryEventsTableComponent } from './components/query-events-table/query-events-table.component';
 import { QueryPipe } from './pipes/query/query.pipe';
 import { TddEventsTableComponent } from './components/tdd-events-table/tdd-events-table.component';
+import { NotConnectedPageComponent } from './pages/not-connected-page/not-connected-page.component';
 
 const mapboxToken =
   'pk.eyJ1IjoiaW9zb25vcGVyc2lhIiwiYSI6ImNsNjBzYjVldjAwNWszaW1rNWZtdTRuNjkifQ.2lGOSvqt5lahEfZYLa3eRg';
@@ -59,6 +60,7 @@ const mapboxToken =
     QueryEventsTableComponent,
     QueryPipe,
     TddEventsTableComponent,
+    NotConnectedPageComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/query-events-table/query-events-table.component.ts
+++ b/src/app/components/query-events-table/query-events-table.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   OnDestroy,
+  OnInit,
   ViewChild,
 } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
@@ -23,7 +24,9 @@ interface IQueryEvent {
   templateUrl: './query-events-table.component.html',
   styleUrls: ['./query-events-table.component.css'],
 })
-export class QueryEventsTableComponent implements AfterViewInit, OnDestroy {
+export class QueryEventsTableComponent
+  implements OnInit, AfterViewInit, OnDestroy
+{
   displayedColumns: string[] = ['blockNumber', 'txHash', 'taskId', 'log'];
 
   dataSource: MatTableDataSource<IQueryEvent>;
@@ -41,6 +44,10 @@ export class QueryEventsTableComponent implements AfterViewInit, OnDestroy {
   ) {
     this.dataSource = new MatTableDataSource<IQueryEvent>(this.txList);
     this.subscriptions = new Subscription();
+  }
+
+  async ngOnInit() {
+    await this.desmold.isReady;
   }
 
   async ngAfterViewInit() {
@@ -65,7 +72,7 @@ export class QueryEventsTableComponent implements AfterViewInit, OnDestroy {
   }
 
   private async getAllCompletedQueries(): Promise<void> {
-    const contract = this.desmold.desmoContract['contract'];
+    const contract = this.desmold.desmo['contract'];
     const queryFilter = contract.filters.QueryCompleted();
     const events = await contract.queryFilter(queryFilter);
     const queryCompletedEvents = events.map((event: any) => {

--- a/src/app/components/tdd-events-table/tdd-events-table.component.ts
+++ b/src/app/components/tdd-events-table/tdd-events-table.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   OnDestroy,
+  OnInit,
   ViewChild,
 } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
@@ -23,7 +24,9 @@ interface ITDDEvent {
   templateUrl: './tdd-events-table.component.html',
   styleUrls: ['./tdd-events-table.component.css'],
 })
-export class TddEventsTableComponent implements AfterViewInit, OnDestroy {
+export class TddEventsTableComponent
+  implements OnInit, AfterViewInit, OnDestroy
+{
   displayedColumns: string[] = ['blockNumber', 'txHash', 'log', 'owner', 'url'];
 
   dataSource: MatTableDataSource<ITDDEvent>;
@@ -45,6 +48,10 @@ export class TddEventsTableComponent implements AfterViewInit, OnDestroy {
       data.owner.toLowerCase().indexOf(filter) !== -1 ||
       data.url.toLowerCase().indexOf(filter) !== -1;
     this.subscriptions = new Subscription();
+  }
+
+  async ngOnInit() {
+    await this.desmold.isReady;
   }
 
   async ngAfterViewInit() {

--- a/src/app/components/transaction-viewer/transaction-viewer.component.css
+++ b/src/app/components/transaction-viewer/transaction-viewer.component.css
@@ -13,3 +13,9 @@
 .card-content {
   margin: 10px;
 }
+
+.horizontalCenter {
+  position: relative;
+  left: 50%;
+  transform: translate(-50%, 0%);
+}

--- a/src/app/components/transaction-viewer/transaction-viewer.component.html
+++ b/src/app/components/transaction-viewer/transaction-viewer.component.html
@@ -5,12 +5,14 @@
   <mat-divider inset></mat-divider>
   <mat-card-content class="card-content">
     <button
-      class="Register-button"
-      mat-raised-button
-      color="primary"
+      class="horizontalCenter"
+      style="margin-bottom: 6px"
+      mat-stroked-button
+      color="warn"
       (click)="clearCache()"
+      [disabled]="txListSize === 0"
     >
-      Clear transactions cache
+      Clear transactions history for this account
     </button>
     <div class="mat-elevation-z4">
       <table mat-table [dataSource]="dataSource" class="full-width">
@@ -60,7 +62,9 @@
       </table>
 
       <mat-paginator
-        [pageSizeOptions]="[5, 10, 20]"
+        [length]="txListSize"
+        [pageSize]="3"
+        [pageSizeOptions]="[3]"
         showFirstLastButtons
         aria-label="Select page of transactions"
       >

--- a/src/app/components/transaction-viewer/transaction-viewer.component.ts
+++ b/src/app/components/transaction-viewer/transaction-viewer.component.ts
@@ -6,7 +6,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
-import { Subscription } from 'rxjs';
+import { Subscription, tap } from 'rxjs';
 import { DesmoldSDKService } from 'src/app/services/desmold-sdk/desmold-sdk.service';
 import { MatPaginator } from '@angular/material/paginator';
 import { OperationType } from '@vaimee/desmold-sdk';
@@ -27,45 +27,70 @@ export class TransactionViewerComponent
 {
   private readonly CACHE_KEY: string = 'transactionList';
   displayedColumns: string[] = ['operation', 'hash', 'sent'];
-  tableData: ITransaction[];
+  txDict: Record<string, ITransaction[]>;
   dataSource: MatTableDataSource<ITransaction>;
+  private subscriptions: Subscription;
+  private currentUserAddress = '';
+  public txListSize = 0;
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
-  ngAfterViewInit() {
-    this.dataSource.paginator = this.paginator;
+  constructor(private desmold: DesmoldSDKService) {
+    // Check the cache for pre-existing data or initialise with an empty object:
+    const txDictStr: string = localStorage.getItem(this.CACHE_KEY) ?? '{}';
+    this.txDict = JSON.parse(txDictStr) as Record<string, ITransaction[]>;
+
+    this.dataSource = new MatTableDataSource<ITransaction>([]);
+    this.subscriptions = new Subscription();
   }
 
-  private subscriptions: Subscription = new Subscription();
-
-  constructor(private desmold: DesmoldSDKService) {
-    // Check the cache for pre-existing data or initialise with an empty list:
-    const txList: string = sessionStorage.getItem(this.CACHE_KEY) ?? '[]';
-    this.tableData = JSON.parse(txList) as ITransaction[];
-    this.dataSource = new MatTableDataSource<ITransaction>(this.tableData);
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+    this.subscriptions.add(
+      this.paginator.page.pipe(tap(() => this.showDataPage())).subscribe()
+    );
   }
 
   async ngOnInit(): Promise<void> {
-    await this.desmold.connect();
+    await this.desmold.isReady;
 
+    if (!this.desmold.desmoHub.isListening) {
+      await this.desmold.desmoHub.startListeners();
+    }
+
+    this.currentUserAddress = this.desmold.userAddress;
+    this.updateTxList();
+
+    // Update the table when the selected account changes:
+    this.subscriptions.add(
+      this.desmold.accountsChanged.subscribe(({ newValue }) => {
+        this.currentUserAddress = newValue;
+        this.updateTxList();
+      })
+    );
+
+    // Transactions subscription:
     this.subscriptions.add(
       this.desmold.desmoHub.transactionSent$.subscribe((tx) => {
-        this.tableData.unshift({
-          invokedOperation: this._fromOperationTypeToString(
-            tx.invokedOperation
-          ),
+        this.txDict[this.currentUserAddress].unshift({
+          invokedOperation: this.fromOperationTypeToString(tx.invokedOperation),
           hash: tx.hash,
           sent: tx.sent,
         } as ITransaction);
-        this.dataSource = new MatTableDataSource<ITransaction>(this.tableData);
 
-        // Save new data inside the cache:
-        sessionStorage.setItem(this.CACHE_KEY, JSON.stringify(this.tableData));
+        this.updateTxList();
       })
     );
   }
 
-  private _fromOperationTypeToString(opType: OperationType): string {
+  public clearCache(): void {
+    if (this.txDict[this.currentUserAddress] !== undefined) {
+      this.txDict[this.currentUserAddress] = [];
+    }
+    this.updateTxList();
+  }
+
+  private fromOperationTypeToString(opType: OperationType): string {
     switch (opType) {
       case OperationType.registerTDD:
         return 'Register TDD';
@@ -80,11 +105,25 @@ export class TransactionViewerComponent
     }
   }
 
-  clearCache(): void {
-    this.tableData = [];
-    this.dataSource = new MatTableDataSource<ITransaction>(this.tableData);
-    // Save new data inside the cache:
-    sessionStorage.setItem(this.CACHE_KEY, JSON.stringify(this.tableData));
+  private updateTxList(): void {
+    // We must be sure that txDict contains an entry for
+    // the newly selected user address:
+    if (this.txDict[this.currentUserAddress] === undefined) {
+      this.txDict[this.currentUserAddress] = [];
+    }
+    this.txListSize = this.txDict[this.currentUserAddress].length;
+
+    this.showDataPage();
+
+    // Update the cache:
+    localStorage.setItem(this.CACHE_KEY, JSON.stringify(this.txDict));
+  }
+
+  private showDataPage() {
+    const start = this.paginator.pageIndex * this.paginator.pageSize;
+    const end = start + this.paginator.pageSize;
+    const data = this.txDict[this.currentUserAddress].slice(start, end);
+    this.dataSource = new MatTableDataSource<ITransaction>(data);
   }
 
   ngOnDestroy(): void {

--- a/src/app/guards/has-metamask/has-metamask.guard.spec.ts
+++ b/src/app/guards/has-metamask/has-metamask.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HasMetamaskGuard } from './has-metamask.guard';
+
+describe('HasMetamaskGuard', () => {
+  let guard: HasMetamaskGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(HasMetamaskGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/guards/has-metamask/has-metamask.guard.ts
+++ b/src/app/guards/has-metamask/has-metamask.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { DesmoldSDKService } from 'src/app/services/desmold-sdk/desmold-sdk.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HasMetamaskGuard implements CanActivate {
+  constructor(private desmold: DesmoldSDKService, private router: Router) {}
+
+  async canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean | UrlTree> {
+    await this.desmold.isReady;
+
+    if (this.desmold.isMetamaskInstalled) {
+      return true;
+    } else {
+      return this.router.parseUrl('/notconnected');
+    }
+  }
+}

--- a/src/app/guards/is-logged-in/is-logged-in.guard.spec.ts
+++ b/src/app/guards/is-logged-in/is-logged-in.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { IsLoggedInGuard } from './is-logged-in.guard';
+
+describe('IsLoggedInGuard', () => {
+  let guard: IsLoggedInGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(IsLoggedInGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/guards/is-logged-in/is-logged-in.guard.ts
+++ b/src/app/guards/is-logged-in/is-logged-in.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { DesmoldSDKService } from 'src/app/services/desmold-sdk/desmold-sdk.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class IsLoggedInGuard implements CanActivate {
+  constructor(private desmold: DesmoldSDKService, private router: Router) {}
+
+  async canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean | UrlTree> {
+    await this.desmold.isReady;
+
+    if (this.desmold.isLoggedIn) {
+      return true;
+    } else {
+      return this.router.parseUrl('/notconnected');
+    }
+  }
+}

--- a/src/app/guards/is-viviani-chain/is-viviani-chain.guard.spec.ts
+++ b/src/app/guards/is-viviani-chain/is-viviani-chain.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { IsVivianiChainGuard } from './is-viviani-chain.guard';
+
+describe('IsVivianiChainGuard', () => {
+  let guard: IsVivianiChainGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(IsVivianiChainGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/guards/is-viviani-chain/is-viviani-chain.guard.ts
+++ b/src/app/guards/is-viviani-chain/is-viviani-chain.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { DesmoldSDKService } from 'src/app/services/desmold-sdk/desmold-sdk.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class IsVivianiChainGuard implements CanActivate {
+  constructor(private desmold: DesmoldSDKService, private router: Router) {}
+
+  async canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean | UrlTree> {
+    await this.desmold.isReady;
+
+    if (this.desmold.isVivianiChain) {
+      return true;
+    } else {
+      return this.router.parseUrl('/notconnected');
+    }
+  }
+}

--- a/src/app/pages/not-connected-page/not-connected-page.component.css
+++ b/src/app/pages/not-connected-page/not-connected-page.component.css
@@ -1,0 +1,19 @@
+.container {
+  height: 80vh;
+  position: relative;
+}
+
+.centerDiv {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border: 6px solid #3f51b5;
+  padding: 20px;
+}
+
+.horizontalCenter {
+  position: relative;
+  left: 50%;
+  transform: translate(-50%, 0%);
+}

--- a/src/app/pages/not-connected-page/not-connected-page.component.html
+++ b/src/app/pages/not-connected-page/not-connected-page.component.html
@@ -1,0 +1,1 @@
+<p>not-connected-page works!</p>

--- a/src/app/pages/not-connected-page/not-connected-page.component.html
+++ b/src/app/pages/not-connected-page/not-connected-page.component.html
@@ -1,1 +1,58 @@
-<p>not-connected-page works!</p>
+<div class="container">
+  <div *ngIf="!isMetamaskInstalled" class="centerDiv">
+    <h1>Oops! Metamask is not installed!</h1>
+    <h3>
+      <a href="https://metamask.io/" target="_blank" style="font-weight: bold"
+        >Metamask</a
+      >
+      is a browser extension that enables user interactions and experience on
+      Web3. <br />
+      Please, install it and refresh the page.
+    </h3>
+    <a
+      href="https://metamask.io/download/"
+      target="_blank"
+      class="horizontalCenter"
+    >
+      <button mat-raised-button color="primary">
+        Install the Metamask extension
+      </button>
+    </a>
+  </div>
+
+  <div *ngIf="isMetamaskInstalled && !isLoggedIn" class="centerDiv">
+    <h1>Oops! Your Metamask account is disconnected!</h1>
+    <h3>Click on the button below to open Metamask's login popup.</h3>
+    <button
+      class="horizontalCenter"
+      mat-raised-button
+      color="primary"
+      (click)="loginToMetamask()"
+    >
+      Log-in
+    </button>
+  </div>
+
+  <div
+    *ngIf="isMetamaskInstalled && isLoggedIn && !isVivianiChain"
+    class="centerDiv"
+  >
+    <h1>Oops! Wrong blockchain selected!</h1>
+    <h3>
+      This application works by interacting with a couple of smart<br />
+      contracts which are deployed on
+      <a href="https://iex.ec/" target="_blank" style="font-weight: bold"
+        >Viviani chain (by iExec)</a
+      >.
+    </h3>
+    <h3>Click on the button below to switch to Viviani chain:</h3>
+    <button
+      class="horizontalCenter"
+      mat-raised-button
+      color="primary"
+      (click)="switchToViviani()"
+    >
+      Switch to Viviani chain
+    </button>
+  </div>
+</div>

--- a/src/app/pages/not-connected-page/not-connected-page.component.spec.ts
+++ b/src/app/pages/not-connected-page/not-connected-page.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotConnectedPageComponent } from './not-connected-page.component';
+
+describe('NotConnectedPageComponent', () => {
+  let component: NotConnectedPageComponent;
+  let fixture: ComponentFixture<NotConnectedPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NotConnectedPageComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NotConnectedPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/not-connected-page/not-connected-page.component.ts
+++ b/src/app/pages/not-connected-page/not-connected-page.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-not-connected-page',
+  templateUrl: './not-connected-page.component.html',
+  styleUrls: ['./not-connected-page.component.css'],
+})
+export class NotConnectedPageComponent {}

--- a/src/app/pages/not-connected-page/not-connected-page.component.ts
+++ b/src/app/pages/not-connected-page/not-connected-page.component.ts
@@ -1,8 +1,91 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import {
+  DesmoldSDKService,
+  IMetamaskError,
+} from 'src/app/services/desmold-sdk/desmold-sdk.service';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-not-connected-page',
   templateUrl: './not-connected-page.component.html',
   styleUrls: ['./not-connected-page.component.css'],
 })
-export class NotConnectedPageComponent {}
+export class NotConnectedPageComponent implements OnInit {
+  constructor(
+    private desmold: DesmoldSDKService,
+    private snackBar: MatSnackBar,
+    private router: Router
+  ) {}
+
+  async ngOnInit(): Promise<void> {
+    await this.desmold.isReady;
+
+    this.checkRedirectCondition();
+  }
+
+  public get isMetamaskInstalled(): boolean {
+    return this.desmold.isMetamaskInstalled;
+  }
+
+  public get isLoggedIn(): boolean {
+    return this.desmold.isLoggedIn;
+  }
+
+  public get isVivianiChain(): boolean {
+    return this.desmold.isVivianiChain;
+  }
+
+  public async loginToMetamask(): Promise<void> {
+    try {
+      await this.desmold.loginToMetamask();
+
+      this.checkRedirectCondition();
+    } catch (error: unknown) {
+      const metamaskError = error as IMetamaskError;
+      this.snackBar.open(metamaskError.message, 'Dismiss', {
+        duration: 3000,
+      });
+    }
+  }
+
+  public async switchToViviani(): Promise<void> {
+    try {
+      await this.desmold.switchToVivianiChain();
+
+      this.checkRedirectCondition();
+    } catch (error: unknown) {
+      const metamaskError = error as IMetamaskError;
+
+      if (metamaskError.code === 4902) {
+        // This error code indicates that the chain has not been added to MetaMask.
+        try {
+          await this.desmold.addVivianiChain();
+
+          this.checkRedirectCondition();
+        } catch (error: unknown) {
+          const metamaskError = error as IMetamaskError;
+          this.snackBar.open(metamaskError.message, 'Dismiss', {
+            duration: 3000,
+          });
+        }
+      } else {
+        this.snackBar.open(metamaskError.message, 'Dismiss', {
+          duration: 3000,
+        });
+      }
+    }
+  }
+
+  private checkRedirectCondition(): void {
+    if (
+      this.desmold.isMetamaskInstalled &&
+      this.desmold.isLoggedIn &&
+      this.desmold.isVivianiChain
+    ) {
+      // There's no reason to display this page:
+      // let's move to the application's home.
+      this.router.navigate(['/']);
+    }
+  }
+}

--- a/src/app/pages/tdd-manager-page/tdd-manager-page.component.ts
+++ b/src/app/pages/tdd-manager-page/tdd-manager-page.component.ts
@@ -28,7 +28,11 @@ export class TddManagerPageComponent implements OnInit, OnDestroy {
   ) {}
 
   async ngOnInit(): Promise<void> {
-    await this.desmold.connect();
+    await this.desmold.isReady;
+
+    if (!this.desmold.desmoHub.isListening) {
+      await this.desmold.desmoHub.startListeners();
+    }
 
     /** Based on the screen size, switch from standard to one column per row */
     this.subscriptions.add(

--- a/src/app/services/desmold-sdk/desmold-sdk.service.ts
+++ b/src/app/services/desmold-sdk/desmold-sdk.service.ts
@@ -1,69 +1,212 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, NgZone, OnDestroy } from '@angular/core';
+import detectEthereumProvider from '@metamask/detect-provider';
 import { Desmo, DesmoHub, WalletSignerMetamask } from '@vaimee/desmold-sdk';
+import { Observable, Subject } from 'rxjs';
+
+export interface IMetamaskError {
+  message: string;
+  code: number;
+  data?: unknown;
+}
+
+export interface IAccountsChangedEvent {
+  oldValue: string;
+  newValue: string;
+}
 
 @Injectable({
   providedIn: 'root',
 })
 export class DesmoldSDKService implements OnDestroy {
-  private _walletSigner: WalletSignerMetamask;
-  private _desmoHub: DesmoHub;
-  private _desmoContract: Desmo;
-  private _isConnected = false;
+  private _ethProvider: any;
+  private _walletSigner?: WalletSignerMetamask;
+  private _desmoHub?: DesmoHub;
+  private _desmo?: Desmo;
+  private _userAddress = 'NOT LOGGED IN';
 
-  constructor() {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    this._walletSigner = new WalletSignerMetamask(window.ethereum);
-    this._isConnected = this._walletSigner.isConnected;
+  // Connection flags:
+  private _isMetamaskInstalled = false;
+  private _isLoggedIn = false;
+  private _isVivianiChain = false;
 
-    this._desmoHub = new DesmoHub(this._walletSigner);
-    this._desmoContract = new Desmo(this._walletSigner);
+  // Promises and observables:
+  private IS_READY: Promise<void>;
+  private ACCOUNTS_CHANGED: Subject<IAccountsChangedEvent>;
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    window.ethereum.on('chainChanged', (chainId: number) =>
-      window.location.reload()
-    );
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    window.ethereum.on('accountsChanged', (accounts: Array<string>) =>
-      window.location.reload()
-    );
+  constructor(private ngZone: NgZone) {
+    this.ACCOUNTS_CHANGED = new Subject<IAccountsChangedEvent>();
+    this.IS_READY = new Promise<void>(async (resolve, reject) => {
+      try {
+        await this.init();
+        resolve();
+      } catch (error) {
+        reject(error);
+      }
+    });
   }
 
   public get desmoHub(): DesmoHub {
+    if (this._desmoHub === undefined) {
+      throw new Error(
+        "DesmoldSDK service isn't ready: please await the isReady promise!"
+      );
+    }
     return this._desmoHub;
   }
 
-  public get desmoContract(): Desmo {
-    return this._desmoContract;
+  public get desmo(): Desmo {
+    if (this._desmo === undefined) {
+      throw new Error(
+        "DesmoldSDK service isn't ready: please await the isReady promise!"
+      );
+    }
+    return this._desmo;
   }
 
-  public get isConnected(): boolean {
-    return this._isConnected;
+  public get userAddress(): string {
+    return this._userAddress;
   }
 
-  public async connect() {
-    if (this.isConnected) {
-      if (!this.desmoHub.isListening) {
-        await this.desmoHub.startListeners();
+  // Connection flags:
+  public get isLoggedIn() {
+    return this._isLoggedIn;
+  }
+
+  public get isVivianiChain() {
+    return this._isVivianiChain;
+  }
+
+  public get isMetamaskInstalled() {
+    return this._isMetamaskInstalled;
+  }
+
+  // Promises and observables:
+  public get isReady(): Promise<void> {
+    return this.IS_READY;
+  }
+
+  public get accountsChanged(): Observable<IAccountsChangedEvent> {
+    return this.ACCOUNTS_CHANGED.asObservable();
+  }
+
+  private async init(): Promise<void> {
+    try {
+      this._ethProvider = await this.getEthereumProvider();
+      this._ethProvider.on('chainChanged', (_chainId: number) =>
+        window.location.reload()
+      );
+      this._ethProvider.on('accountsChanged', (accounts: Array<string>) =>
+        this.ngZone.run(async () => {
+          // Bring event back inside Angular's zone
+          await this.handleAccountsChanged(accounts);
+        })
+      );
+
+      // Set flag isMetamaskInstalled:
+      this._isMetamaskInstalled = true;
+
+      // Set flag isLoggedIn:
+      const accounts = await this._ethProvider.request({
+        method: 'eth_accounts',
+      });
+      this._isLoggedIn = accounts.length > 0;
+      if (this._isLoggedIn) {
+        this._userAddress = accounts[0];
       }
+
+      // Set flag isVivianiChain:
+      const chainId: string = await this._ethProvider.request({
+        method: 'eth_chainId',
+      });
+      this._isVivianiChain = chainId === '0x85';
+
+      // Initialize SDK interfaces:
+      this._walletSigner = new WalletSignerMetamask(this._ethProvider);
+      this._desmoHub = new DesmoHub(this._walletSigner);
+      this._desmo = new Desmo(this._walletSigner);
+    } catch {
+      this._isMetamaskInstalled = false;
+      this._isLoggedIn = false;
+      this._isVivianiChain = false;
+    }
+  }
+
+  private async handleAccountsChanged(accounts: Array<string>): Promise<void> {
+    await this.isReady;
+
+    this._isLoggedIn = accounts.length > 0;
+    if (!this._isLoggedIn) {
+      // The user disconnected from Metamask:
+      // reload the page to restart from scratch.
+      window.location.reload();
       return;
     }
 
-    // This needs to be done immediately, in order to prevent other async functions
-    // that may have called connect() to execute the subsequent lines of code!
-    this._isConnected = true;
+    if (
+      this._walletSigner !== undefined &&
+      this._desmoHub !== undefined &&
+      this._desmo !== undefined
+    ) {
+      if (!this._walletSigner.isConnected) {
+        await this._walletSigner.connect();
+        this._desmoHub.connect();
+        this._desmo.connect();
+      }
 
-    await this._walletSigner.connect();
-    this.desmoHub.connect();
-    this.desmoContract.connect();
+      if (this._desmoHub.isListening) {
+        this._desmoHub.stopListeners();
+        await this._desmoHub.startListeners();
+      }
+    }
 
-    await this.desmoHub.startListeners();
+    // Update the user address and emit the event:
+    this.ACCOUNTS_CHANGED.next({
+      oldValue: this._userAddress,
+      newValue: accounts[0],
+    });
+    this._userAddress = accounts[0];
+  }
+
+  public async loginToMetamask(): Promise<void> {
+    await this._ethProvider.request({ method: 'eth_requestAccounts' });
+  }
+
+  public async switchToVivianiChain(): Promise<void> {
+    await this._ethProvider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: '0x85' }],
+    });
+  }
+
+  public async addVivianiChain(): Promise<void> {
+    await this._ethProvider.request({
+      method: 'wallet_addEthereumChain',
+      params: [
+        {
+          chainId: '0x85',
+          chainName: 'Viviani',
+          rpcUrls: ['https://viviani.iex.ec'],
+          blockExplorerUrls: ['https://blockscout-viviani.iex.ec/'],
+          nativeCurrency: {
+            symbol: 'RLC',
+            decimals: 18,
+          },
+        },
+      ],
+    });
+  }
+
+  private async getEthereumProvider(): Promise<unknown> {
+    const provider: unknown = await detectEthereumProvider({
+      mustBeMetaMask: true,
+      silent: false,
+      timeout: 3000,
+    });
+    return provider;
   }
 
   ngOnDestroy() {
-    if (this.desmoHub.isListening) {
+    if (this.desmoHub?.isListening) {
       this.desmoHub.stopListeners();
     }
   }


### PR DESCRIPTION
Closes #17. Replaces #21.

The DesmoldSDK service gets almost completely rewritten.

A new page is shown when either Metamask isn't installed, the selected chain isn't Viviani or the user isn't logged in.
In each situation, a proper message is shown at the center of the page with an action button that allows the user to solve the problem in just a bit more than a click.

If the user didn't add the Viviani chain to its Metamask configuration, the button for switching to Viviani chain will also properly configure such chain.

Better error handling overall, with snackbar popups shown instead of using console.error (some errors can still appear in the console: they're thrown by Metamask itself).

Fixed the appearance of the two components in the TddManager page.

If the user changes chain or disconnects in the Metamask plugin, the page gets reloaded.
If the user changes account (wallet) in the Metamask plugin, the application handles this situation by updating dynamically its interfaces with the contracts.